### PR TITLE
Fix subtask progress rendering and mobile AI header layout

### DIFF
--- a/ai.js
+++ b/ai.js
@@ -1632,9 +1632,6 @@
  .tm-ai-sidebar__task-row span{flex:1;min-width:0;word-break:break-word;}
  .tm-ai-sidebar__empty{padding:14px 10px;border:1px dashed var(--b3-theme-surface-light);border-radius:10px;font-size:12px;opacity:.72;}
 .tm-ai-sidebar--mobile .tm-ai-sidebar__head{padding-top:8px;}
-.tm-ai-sidebar--mobile .tm-ai-sidebar__head{flex-wrap:wrap;align-items:flex-start;}
-.tm-ai-sidebar--mobile .tm-ai-sidebar__head-title{order:3;flex:1 1 100%;max-width:none;}
-.tm-ai-sidebar--mobile .tm-ai-sidebar__head-actions{width:100%;justify-content:flex-end;}
 .tm-ai-sidebar--mobile .tm-ai-sidebar__grid,
 .tm-ai-sidebar--mobile .tm-ai-sidebar__grid--planner{grid-template-columns:repeat(2,minmax(0,1fr));}
 @media (max-width: 360px){

--- a/task.js
+++ b/task.js
@@ -11009,7 +11009,7 @@ async function __tmRefreshAfterWake(reason) {
             const groupBg = enableGroupBg ? (currentGroupBg || resolvePinnedTaskGroupBg(task)) : '';
             const doneSubtaskBg = (!enableGroupBg && isDoneSubtask) ? __tmWithAlpha(progressBarColor, isDark ? 0.22 : 0.14) : '';
             const baseBg = groupBg || doneSubtaskBg;
-            const progressBgStyle = (row.hasChildren && progressPercent > 0)
+            const progressBgStyle = (totalChildren > 0 && progressPercent > 0)
                 ? (enableGroupBg && groupBg
                     ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                     : `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
@@ -15952,7 +15952,7 @@ async function __tmRefreshAfterWake(reason) {
                 const groupBg = enableGroupBg ? (currentGroupBg || resolvePinnedTaskGroupBg(task)) : '';
                 const doneSubtaskBg = (!enableGroupBg && isDoneSubtask) ? __tmWithAlpha(progressBarColor, isDark ? 0.22 : 0.14) : '';
                 const baseBg = groupBg || doneSubtaskBg;
-                const progressBgStyle = (row.hasChildren && progressPercent > 0)
+                const progressBgStyle = (totalChildren > 0 && progressPercent > 0)
                     ? (enableGroupBg && groupBg
                         ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                         : `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
@@ -27558,7 +27558,7 @@ async function __tmRefreshAfterWake(reason) {
                 ? __tmNormalizeHexColor(SettingsStore.data.progressBarColorDark, '#81c784')
                 : __tmNormalizeHexColor(SettingsStore.data.progressBarColorLight, '#4caf50');
             const groupBg = enableGroupBg ? (currentGroupBg || resolvePinnedTaskGroupBg(task)) : '';
-            const progressBgStyle = (hasChildren && progressPercent > 0)
+            const progressBgStyle = (totalChildren > 0 && progressPercent > 0)
                 ? (enableGroupBg && groupBg
                     ? `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                     : `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)


### PR DESCRIPTION
### Motivation
- The subtask progress bar disappeared in some views because the rendering used view-dependent `hasChildren`/`row.hasChildren` flags instead of actual child counts, causing progress to hide when children were filtered out. 
- The AI workspace header on mobile was forced to wrap into multiple lines by a mobile-specific CSS rule, producing a different layout from desktop.

### Description
- Use the real child counts when deciding to render the progress background by replacing `row.hasChildren`/`hasChildren` checks with `totalChildren > 0 && progressPercent > 0` in the task render paths, so the progress bar shows whenever a task actually has subtasks and non-zero completion. (changes in `task.js` across timeline/list/emitRow renderers)
- Restore the AI sidebar header to the desktop single-line layout by removing the mobile-only `flex-wrap`/ordering rules and keeping wrap behavior only under the narrow `@media (max-width: 360px)` rule in `ai.js`.
- Modified files: `task.js`, `ai.js`.

### Testing
- Ran `node --check task.js` and the syntax check succeeded. 
- Ran `node --check ai.js` and the syntax check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb47286f9083268c5b32bb9e267627)