### PR TITLE
fix: preserve completed subtasks for progress rendering

### DIFF
--- a/task.js
+++ b/task.js
@@ -7958,17 +7958,10 @@
                 console.error(`[查询] 文档 ${did.slice(0, 8)} 查询失败:`, res.msg);
                 return { tasks: [], queryTime };
             }
-            let tasks = Array.isArray(res.data) ? res.data : [];
-            if (!ignoreExcludeCompleted && SettingsStore.data.excludeCompletedTasks && !(options && options.doneOnly === true)) {
-                tasks = tasks.filter((task) => {
-                    try {
-                        const parsed = API.parseTaskStatus(task?.markdown);
-                        return !parsed?.done;
-                    } catch (e) {
-                        return !task?.done;
-                    }
-                });
-            }
+            const tasks = Array.isArray(res.data) ? res.data : [];
+            // 注意：这里不能提前过滤已完成任务。
+            // 子任务进度条、父子层级和“父任务未完成时显示已完成子任务”的规则，都依赖完整树结构。
+            // 真正的显隐交给 applyFilters/filterVisibleTasks 统一处理。
             return { tasks, queryTime };
         },
 
@@ -8111,17 +8104,10 @@
                     return { tasks: [], queryTime };
                 }
             }
-            let tasks = Array.isArray(res.data) ? res.data : [];
-            if (!ignoreExcludeCompleted && SettingsStore.data.excludeCompletedTasks && !doneOnly) {
-                tasks = tasks.filter((task) => {
-                    try {
-                        const parsed = API.parseTaskStatus(task?.markdown);
-                        return !parsed?.done;
-                    } catch (e) {
-                        return !task?.done;
-                    }
-                });
-            }
+            const tasks = Array.isArray(res.data) ? res.data : [];
+            // 注意：这里不能提前过滤已完成任务。
+            // 子任务进度条、父子层级和“父任务未完成时显示已完成子任务”的规则，都依赖完整树结构。
+            // 真正的显隐交给 applyFilters/filterVisibleTasks 统一处理。
             const out = { tasks, queryTime };
             __tmTasksQueryCache.set(cacheKey, { t: Date.now(), v: out, docIdSet });
             return out;


### PR DESCRIPTION
### Motivation
- 子任务进度条在表格/清单等视图消失，原因是查询层在 SQL 结果返回后提前把已完成任务从结果中过滤掉，导致内存中的任务树缺失已完成子任务，父任务无法计算子任务进度。
- 可见性与显隐本应由现有的 `applyFilters` / `filterVisibleTasks` 层统一处理，而不是在索引查询后就丢弃数据。

### Description
- 在 `getTasksByDocument` / `getTasksByDocuments` 中移除对查询结果提前过滤已完成任务的逻辑，改为直接返回从 SQL 得到的完整 `tasks` 数组并添加注释说明原因。
- 保留原有的后端 SQL 查询与缓存逻辑，仅调整结果处理部分以保证完整任务树可用用于父子层级与进度计算。
- 变更文件：`task.js`（删除提前过滤、新增注释说明，保持其他行为不变）。

### Testing
- 运行 `node --check task.js` 检查语法，结果通过且未报错。
- 运行空白/换行检查 `git -c core.whitespace=cr-at-eol diff --check`，结果通过（无影响运行时的差异错误）。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb4cee4ba883269b5c80178051c49b)