### PR TITLE
Defer completed-task filtering and unify progress bar background styling

### DIFF
--- a/task.js
+++ b/task.js
@@ -7958,17 +7958,10 @@
                 console.error(`[查询] 文档 ${did.slice(0, 8)} 查询失败:`, res.msg);
                 return { tasks: [], queryTime };
             }
-            let tasks = Array.isArray(res.data) ? res.data : [];
-            if (!ignoreExcludeCompleted && SettingsStore.data.excludeCompletedTasks && !(options && options.doneOnly === true)) {
-                tasks = tasks.filter((task) => {
-                    try {
-                        const parsed = API.parseTaskStatus(task?.markdown);
-                        return !parsed?.done;
-                    } catch (e) {
-                        return !task?.done;
-                    }
-                });
-            }
+            const tasks = Array.isArray(res.data) ? res.data : [];
+            // 注意：这里不能提前过滤已完成任务。
+            // 子任务进度条、父子层级和“父任务未完成时显示已完成子任务”的规则，都依赖完整树结构。
+            // 真正的显隐交给 applyFilters/filterVisibleTasks 统一处理。
             return { tasks, queryTime };
         },
 
@@ -8111,17 +8104,10 @@
                     return { tasks: [], queryTime };
                 }
             }
-            let tasks = Array.isArray(res.data) ? res.data : [];
-            if (!ignoreExcludeCompleted && SettingsStore.data.excludeCompletedTasks && !doneOnly) {
-                tasks = tasks.filter((task) => {
-                    try {
-                        const parsed = API.parseTaskStatus(task?.markdown);
-                        return !parsed?.done;
-                    } catch (e) {
-                        return !task?.done;
-                    }
-                });
-            }
+            const tasks = Array.isArray(res.data) ? res.data : [];
+            // 注意：这里不能提前过滤已完成任务。
+            // 子任务进度条、父子层级和“父任务未完成时显示已完成子任务”的规则，都依赖完整树结构。
+            // 真正的显隐交给 applyFilters/filterVisibleTasks 统一处理。
             const out = { tasks, queryTime };
             __tmTasksQueryCache.set(cacheKey, { t: Date.now(), v: out, docIdSet });
             return out;
@@ -11010,9 +10996,7 @@ async function __tmRefreshAfterWake(reason) {
             const doneSubtaskBg = (!enableGroupBg && isDoneSubtask) ? __tmWithAlpha(progressBarColor, isDark ? 0.22 : 0.14) : '';
             const baseBg = groupBg || doneSubtaskBg;
             const progressBgStyle = (row.hasChildren && progressPercent > 0)
-                ? (enableGroupBg && groupBg
-                    ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                    : `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                 : '';
             const contentCellBgStyle = `${baseBg ? `background-color:${baseBg};` : ''}${progressBgStyle ? `${progressBgStyle};` : ''}`;
             const otherCellBgStyle = groupBg ? `background-color:${groupBg};` : '';
@@ -15953,9 +15937,7 @@ async function __tmRefreshAfterWake(reason) {
                 const doneSubtaskBg = (!enableGroupBg && isDoneSubtask) ? __tmWithAlpha(progressBarColor, isDark ? 0.22 : 0.14) : '';
                 const baseBg = groupBg || doneSubtaskBg;
                 const progressBgStyle = (row.hasChildren && progressPercent > 0)
-                    ? (enableGroupBg && groupBg
-                        ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                        : `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                    ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                     : '';
                 const contentCellBgStyle = `${baseBg ? `background-color:${baseBg};` : ''}${progressBgStyle ? `${progressBgStyle};` : ''}`;
                 const otherCellBgStyle = groupBg ? `background-color:${groupBg};` : '';
@@ -27559,9 +27541,7 @@ async function __tmRefreshAfterWake(reason) {
                 : __tmNormalizeHexColor(SettingsStore.data.progressBarColorLight, '#4caf50');
             const groupBg = enableGroupBg ? (currentGroupBg || resolvePinnedTaskGroupBg(task)) : '';
             const progressBgStyle = (hasChildren && progressPercent > 0)
-                ? (enableGroupBg && groupBg
-                    ? `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                    : `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                ? `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                 : '';
             
             const contentIndent = 12 + depth * 16;


### PR DESCRIPTION
### Motivation

- Ensure task tree and derived UI (subtask progress bars, parent/child visibility rules) operate on the complete task tree instead of a pre-filtered subset. 
- Avoid premature removal of completed tasks in query helpers so visibility decisions are centralized.
- Make progress bar rendering consistent by always including sizing and positioning CSS for the gradient.

### Description

- In `task.js`, stopped filtering out completed tasks early in `getTasksByDocument` and `getTasksByDocuments`; both now return the full task list and include a comment explaining that visibility should be handled by `applyFilters`/`filterVisibleTasks`.
- Replaced `let tasks` with `const tasks` for the query results in both helpers. 
- Standardized the `progressBgStyle` generation so the gradient always includes `background-size:100% 3px` and `background-position:left bottom`, removing the conditional branch that produced different CSS when `enableGroupBg && groupBg` was true.
- Minor whitespace/formatting adjustments in the affected `task.js` template renderers to keep styles consistent.

### Testing

- Ran the project's test suite with `npm test` and all unit tests passed. 
- Performed a quick build check with `npm run build` and verified there were no build errors. 
- Manual smoke verification of the task list UI confirmed tasks are returned intact and progress bars render with the updated gradient styling.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb4cee4ba883269b5c80178051c49b)