### PR TITLE
fix: align table view subtask progress bars

### DIFF
--- a/task.js
+++ b/task.js
@@ -27543,8 +27543,8 @@ async function __tmRefreshAfterWake(reason) {
             const progressBgStyle = (hasChildren && progressPercent > 0)
                 ? `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                 : '';
-            
             const contentIndent = 12 + depth * 16;
+            const contentCellStyle = `padding-left:${contentIndent}px;${progressBgStyle}`;
             const treeGuides = depth > 0
                 ? `<span class="tm-tree-guides" aria-hidden="true">${Array.from({ length: depth }, (_, i) => `<span class="tm-tree-guide-line" style="left:${18 + i * 16}px"></span>`).join('')}</span>`
                 : '';
@@ -27572,8 +27572,8 @@ async function __tmRefreshAfterWake(reason) {
                                title="置顶">
                     </td>`,
                 content: () => `
-                    <td class="tm-task-content-cell" style="width: ${widths.content || 360}px; min-width: ${widths.content || 360}px; max-width: ${widths.content || 360}px; ${progressBgStyle}">
-                        <div class="tm-task-cell" style="padding-left:${contentIndent}px">
+                    <td class="tm-task-content-cell" style="width: ${widths.content || 360}px; min-width: ${widths.content || 360}px; max-width: ${widths.content || 360}px;">
+                        <div class="tm-task-cell" style="${contentCellStyle}">
                             ${treeGuides}
                             <span class="${leadingClass}">
                                 ${leadingRing}


### PR DESCRIPTION
### Motivation
- 修复表格视图中子任务进度条在某些行出现 1px 垂直抖动的问题，原因是进度条背景直接绘制在 `<td>` 底部受表格折叠/边框影响而产生绘制误差。

### Description
- 将进度条背景从 `td`（`.tm-task-content-cell`）移动到固定行高的内层容器 `.tm-task-cell`，并通过新增的 `contentCellStyle` 把原有的缩进和进度条背景合并为内联样式以保证在稳定的盒子上渲染（变更位于 `task.js` 的表格视图行渲染逻辑）。

### Testing
- 运行了 `node --check task.js`，语法检查通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5157cd90832693e62cf798a7a36d)