### PR TITLE
Normalize subtask progress bar height in table and timeline rows

### DIFF
--- a/task.js
+++ b/task.js
@@ -11010,9 +11010,7 @@ async function __tmRefreshAfterWake(reason) {
             const doneSubtaskBg = (!enableGroupBg && isDoneSubtask) ? __tmWithAlpha(progressBarColor, isDark ? 0.22 : 0.14) : '';
             const baseBg = groupBg || doneSubtaskBg;
             const progressBgStyle = (row.hasChildren && progressPercent > 0)
-                ? (enableGroupBg && groupBg
-                    ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                    : `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                 : '';
             const contentCellBgStyle = `${baseBg ? `background-color:${baseBg};` : ''}${progressBgStyle ? `${progressBgStyle};` : ''}`;
             const otherCellBgStyle = groupBg ? `background-color:${groupBg};` : '';
@@ -27559,9 +27557,7 @@ async function __tmRefreshAfterWake(reason) {
                 : __tmNormalizeHexColor(SettingsStore.data.progressBarColorLight, '#4caf50');
             const groupBg = enableGroupBg ? (currentGroupBg || resolvePinnedTaskGroupBg(task)) : '';
             const progressBgStyle = (hasChildren && progressPercent > 0)
-                ? (enableGroupBg && groupBg
-                    ? `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                    : `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                ? `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
                 : '';
             
             const contentIndent = 12 + depth * 16;


### PR DESCRIPTION
### Motivation
- In the table/list/timeline views adjacent parent tasks with subtasks showed a 1px visual height difference in the subtask progress bars, causing a misaligned appearance. 
- Root cause: two rendering paths produced different CSS for the progress background (one omitted explicit `background-size`/position), so the progress indicator height could differ between rows.

### Description
- Unified the progress bar background generation in `task.js` so both table and timeline row renderers always apply a gradient with `background-size:100% 3px` and `background-position:left bottom` for parent-task progress bars. 
- Removed the conditional branch that previously emitted a gradient without fixed size/position, ensuring consistent 3px bottom progress bars across views. 
- Changes are limited to `task.js` (two locations where `progressBgStyle` was computed) and the existing `contentCellBgStyle` continues to combine base background and progress background.

### Testing
- Ran `node --check task.js` to validate the modified file syntax and the check passed. 
- No automated visual tests were available in this environment, so UI verification should be performed in-browser to confirm the alignment fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb5418b404832698089d646041e78d)