### PR TITLE
Fix inconsistent table subtask progress height

### DIFF
--- a/task.js
+++ b/task.js
@@ -10298,6 +10298,17 @@ async function __tmRefreshAfterWake(reason) {
         return `rgba(${rgb.r}, ${rgb.g}, ${rgb.b}, ${a})`;
     }
 
+    function __tmBuildTaskProgressBgStyle(progressColor, progressPercent, options = {}) {
+        const percent = __tmClamp(Number(progressPercent) || 0, 0, 100);
+        const color = String(progressColor || '').trim();
+        if (!color || percent <= 0) return '';
+        const barOnly = !!options.barOnly;
+        // 非条形模式时预留底部 1px 给表格 inset 边框，避免连续父任务行出现视觉上高 1px 的错位。
+        const size = barOnly ? '100% 3px' : '100% calc(100% - 1px)';
+        const position = barOnly ? 'left bottom' : 'left top';
+        return `background-image:linear-gradient(90deg, ${color} ${percent}%, transparent ${percent}%);background-repeat:no-repeat;background-size:${size};background-position:${position};`;
+    }
+
     function __tmBuildStatusChipStyle(color) {
         const base = __tmNormalizeHexColor(color, '#757575') || '#757575';
         const darkMode = __tmIsDarkMode();
@@ -10996,9 +11007,7 @@ async function __tmRefreshAfterWake(reason) {
             const doneSubtaskBg = (!enableGroupBg && isDoneSubtask) ? __tmWithAlpha(progressBarColor, isDark ? 0.22 : 0.14) : '';
             const baseBg = groupBg || doneSubtaskBg;
             const progressBgStyle = (row.hasChildren && progressPercent > 0)
-                ? (enableGroupBg && groupBg
-                    ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                    : `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                ? __tmBuildTaskProgressBgStyle(progressBarColor, progressPercent, { barOnly: enableGroupBg && !!groupBg })
                 : '';
             const contentCellBgStyle = `${baseBg ? `background-color:${baseBg};` : ''}${progressBgStyle ? `${progressBgStyle};` : ''}`;
             const otherCellBgStyle = groupBg ? `background-color:${groupBg};` : '';
@@ -15939,9 +15948,7 @@ async function __tmRefreshAfterWake(reason) {
                 const doneSubtaskBg = (!enableGroupBg && isDoneSubtask) ? __tmWithAlpha(progressBarColor, isDark ? 0.22 : 0.14) : '';
                 const baseBg = groupBg || doneSubtaskBg;
                 const progressBgStyle = (row.hasChildren && progressPercent > 0)
-                    ? (enableGroupBg && groupBg
-                        ? `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                        : `background-image:linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                    ? __tmBuildTaskProgressBgStyle(progressBarColor, progressPercent, { barOnly: enableGroupBg && !!groupBg })
                     : '';
                 const contentCellBgStyle = `${baseBg ? `background-color:${baseBg};` : ''}${progressBgStyle ? `${progressBgStyle};` : ''}`;
                 const otherCellBgStyle = groupBg ? `background-color:${groupBg};` : '';
@@ -27545,9 +27552,7 @@ async function __tmRefreshAfterWake(reason) {
                 : __tmNormalizeHexColor(SettingsStore.data.progressBarColorLight, '#4caf50');
             const groupBg = enableGroupBg ? (currentGroupBg || resolvePinnedTaskGroupBg(task)) : '';
             const progressBgStyle = (hasChildren && progressPercent > 0)
-                ? (enableGroupBg && groupBg
-                    ? `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;background-size:100% 3px;background-position:left bottom;`
-                    : `background-image: linear-gradient(90deg, ${progressBarColor} ${progressPercent}%, transparent ${progressPercent}%);background-repeat:no-repeat;`)
+                ? __tmBuildTaskProgressBgStyle(progressBarColor, progressPercent, { barOnly: enableGroupBg && !!groupBg })
                 : '';
             
             const contentIndent = 12 + depth * 16;


### PR DESCRIPTION
### Motivation
- In the table view when multiple parent tasks with subtasks are adjacent, some rows displayed the subtask progress background 1px taller, producing a visible misalignment.
- The change aims to unify how progress backgrounds are rendered so consecutive parent-task rows appear visually consistent.

### Description
- Add a shared helper `__tmBuildTaskProgressBgStyle(progressColor, progressPercent, options)` to centralize generation of the progress background CSS and sizing rules.
- Reserve the bottom 1px (unless explicitly rendering a compact bar) for the table inset border to avoid a 1px visual height difference between adjacent filled rows.
- Replace inline gradient constructions in the table/timeline renderers to call the new helper so all row renderers use the same sizing logic.

### Testing
- Ran `node --check task.js` to verify syntax and the file passed the check successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb589de2a08326a5c9ce576720141e)