### PR TITLE
Fix topbar/menu readability and mobile view switcher overflow

### DIFF
--- a/task.js
+++ b/task.js
@@ -921,6 +921,20 @@
             border: 1px solid var(--tm-input-border);
         }
 
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu .tm-mobile-menu-label,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu .bc-select-trigger,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu .bc-select-option,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu .tm-view-seg-item,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu .tm-btn {
+            color: #1f2329 !important;
+        }
+
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu .tm-view-seg-item--active,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmMobileMenu .tm-btn.tm-btn-primary {
+            color: #ffffff !important;
+        }
+
         .tm-filter-rule-bar #tmMobileMenu .tm-view-segmented {
             background: var(--tm-input-bg);
             border: 1px solid var(--tm-input-border);
@@ -963,18 +977,17 @@
         .tm-header-selectors {
             min-width: 0;
             flex-wrap: nowrap;
-            overflow-x: auto;
-            overflow-y: visible;
-            -webkit-overflow-scrolling: touch;
+            overflow: hidden;
         }
 
-        .tm-header-selectors::-webkit-scrollbar {
-            height: 4px;
+        .tm-filter-rule-bar .tm-search-box,
+        .tm-filter-rule-bar .tm-header-selectors {
+            scrollbar-width: none;
         }
 
-        .tm-header-selectors::-webkit-scrollbar-thumb {
-            background: var(--tm-topbar-scrollbar-thumb);
-            border-radius: 999px;
+        .tm-filter-rule-bar .tm-search-box::-webkit-scrollbar,
+        .tm-filter-rule-bar .tm-header-selectors::-webkit-scrollbar {
+            display: none;
         }
         
         .tm-rule-display {
@@ -1575,18 +1588,7 @@
             align-items: center;
             gap: 8px;
             flex-wrap: nowrap;
-            overflow-x: auto;
-            overflow-y: visible;
-            -webkit-overflow-scrolling: touch;
-        }
-
-        .tm-search-box::-webkit-scrollbar {
-            height: 4px;
-        }
-
-        .tm-search-box::-webkit-scrollbar-thumb {
-            background: var(--tm-topbar-scrollbar-thumb);
-            border-radius: 999px;
+            overflow: hidden;
         }
 
         .tm-view-segmented {
@@ -1626,6 +1628,23 @@
         .tm-filter-rule-bar .bc-tabs-trigger {
             height: 30px !important;
             min-height: 30px !important;
+            font-size: 13px !important;
+            font-weight: 500 !important;
+        }
+
+        .tm-filter-rule-bar .bc-btn,
+        .tm-filter-rule-bar .bc-btn--sm,
+        .tm-filter-rule-bar .bc-select-trigger,
+        .tm-filter-rule-bar .tm-view-seg-item,
+        .tm-filter-rule-bar .tm-mobile-menu-btn button {
+            font-weight: 500 !important;
+            font-size: 13px !important;
+        }
+
+        .tm-filter-rule-bar {
+            min-height: 52px;
+            box-sizing: border-box;
+            overflow: visible;
         }
 
         .tm-filter-rule-bar .bc-tabs-list {
@@ -1672,6 +1691,35 @@
 
         .tm-filter-rule-bar .tm-topbar-select--wide {
             min-width: 0;
+        }
+
+        .tm-filter-rule-bar #tmMobileMenu {
+            color: var(--tm-text-color);
+        }
+
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-view-switcher-wrap {
+            overflow: hidden;
+        }
+
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-view-switcher {
+            width: 100%;
+            min-width: 0;
+            display: flex;
+            flex-wrap: wrap;
+            justify-content: flex-start;
+            height: auto !important;
+            min-height: 0 !important;
+            gap: 4px;
+            padding: 4px;
+        }
+
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-view-switcher .tm-view-seg-item {
+            min-height: 24px !important;
+            height: 24px !important;
+            line-height: 24px !important;
+            font-size: 12px !important;
+            padding: 0 8px !important;
+            border-radius: 6px;
         }
 
         .tm-view-seg-item:hover {
@@ -20716,8 +20764,8 @@ async function __tmRefreshAfterWake(reason) {
                             <div style="display:flex; flex-direction:column; gap:10px;">
                                 <div class="tm-mobile-only-item" style="display:flex; flex-direction:column; gap:6px; align-items:stretch;">
                                     <span style="color:var(--tm-text-color);">视图:</span>
-                                    <div style="overflow-x:auto; -webkit-overflow-scrolling:touch;">
-                                        <div class="tm-view-segmented bc-tabs-list" role="tablist" aria-label="视图" style="height:28px; min-width:max-content;">
+                                    <div class="tm-mobile-view-switcher-wrap">
+                                        <div class="tm-view-segmented bc-tabs-list tm-mobile-view-switcher" role="tablist" aria-label="视图">
                                             ${__tmRenderViewSwitcherButtons({ compact: true })}
                                         </div>
                                     </div>


### PR DESCRIPTION
### Motivation
- Prevent the view selector and mobile menu from overflowing and producing horizontal/vertical scrollbars in dock and mobile contexts. 
- Ensure topbar menu text remains readable in light/day theme when topbar uses a light background. 
- Harmonize topbar control typography so dropdowns, menu buttons and segmented view controls are not bold and use a consistent size. 
- Stop the topbar from changing height or allowing its controls to scroll as a whole when switching views (e.g. calendar) to avoid visual jumps and extra scrollbars. 

### Description
- Updated `task.js` CSS to force dark text for items inside the mobile menu under light theme using `[data-theme-mode="light"]` selectors. 
- Hid internal scrollbars and replaced overflow behavior for `.tm-header-selectors` and `.tm-search-box` to avoid visible scroll rails and whole-control scrolling. 
- Unified topbar control typography by setting `font-size: 13px` and `font-weight: 500` for relevant selectors (`.bc-btn`, `.bc-select-trigger`, `.tm-view-seg-item`, etc.) and added a stable `min-height` for the filter/topbar area. 
- Replaced the mobile menu view switcher container with a wrapping element and added compact, wrap-capable styles (`.tm-mobile-view-switcher-wrap` / `.tm-mobile-view-switcher`) to shrink buttons and prevent right-side overflow. 
- Change is limited to UI markup/classes and CSS changes inside `task.js` with no functional logic changes. 

### Testing
- Ran `node --check task.js` which completed successfully. 
- No other automated tests were applicable for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4b5fc518c83269753639e1bf7e86c)