### PR TITLE
style: improve desktop menu contrast, bold view selector, tighten mobile menu spacing

### DIFF
--- a/task.js
+++ b/task.js
@@ -935,6 +935,13 @@
             color: #ffffff !important;
         }
 
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn span,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-tree-toggle-icon {
+            color: #1f2329 !important;
+        }
+
         .tm-filter-rule-bar #tmMobileMenu .tm-view-segmented {
             background: var(--tm-input-bg);
             border: 1px solid var(--tm-input-border);
@@ -1641,6 +1648,10 @@
             font-size: 13px !important;
         }
 
+        .tm-filter-rule-bar .tm-view-segmented .tm-view-seg-item {
+            font-weight: 600 !important;
+        }
+
         .tm-filter-rule-bar {
             min-height: 52px;
             box-sizing: border-box;
@@ -1702,7 +1713,8 @@
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-mobile-view-switcher {
-            width: 100%;
+            width: max-content;
+            max-width: 100%;
             min-width: 0;
             display: flex;
             flex-wrap: wrap;
@@ -1710,7 +1722,7 @@
             height: auto !important;
             min-height: 0 !important;
             gap: 4px;
-            padding: 4px;
+            padding: 4px 0 4px 4px;
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-mobile-view-switcher .tm-view-seg-item {


### PR DESCRIPTION
### Motivation
- Fix readability in light (day) mode by ensuring the desktop popup menu uses dark text/icons.
- Make the view selector more prominent by increasing font weight.
- Reduce excess whitespace on the right side of the mobile view switcher to improve compactness.

### Description
- Added light-mode rules targeting `#tmDesktopMenu` to force dark text/icons (`color: #1f2329`) for buttons and inline spans in `task.js` CSS.
- Increased weight of view switcher buttons by setting `.tm-filter-rule-bar .tm-view-segmented .tm-view-seg-item { font-weight: 600 !important; }` in `task.js`.
- Changed the mobile view switcher layout to `width: max-content`, added `max-width: 100%`, and adjusted padding to `padding: 4px 0 4px 4px` to tighten right-side whitespace in `task.js`.
- File modified: `task.js` (CSS/inline style changes).

### Testing
- Ran `node --check task.js` to validate the JS file syntax and it succeeded.
- No automated visual/browser tests were run in this change set (CSS-only adjustments).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4be811ab4832686d6d6f5ecd29a7b)