### PR TITLE
fix: 优化顶栏浅色菜单字体与移动端菜单宽度

### DIFF
--- a/task.js
+++ b/task.js
@@ -938,8 +938,12 @@
         [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu,
         [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn,
         [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn span,
-        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-tree-toggle-icon {
-            color: #1f2329 !important;
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-tree-toggle-icon,
+        [data-theme-mode="light"] .tm-filter-rule-bar .tm-topbar-select .bc-select-trigger,
+        [data-theme-mode="light"] .tm-filter-rule-bar .tm-topbar-select .bc-select-option,
+        [data-theme-mode="light"] #tmTopbarFloatingMenu,
+        [data-theme-mode="light"] #tmTopbarFloatingMenu .bc-select-option {
+            color: #000000 !important;
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-view-segmented {
@@ -1713,7 +1717,7 @@
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-mobile-view-switcher {
-            width: max-content;
+            width: 100%;
             max-width: 100%;
             min-width: 0;
             display: flex;
@@ -26938,6 +26942,17 @@ async function __tmRefreshAfterWake(reason) {
         const open = menu.style.display !== 'none';
         if (!open) {
             menu.style.display = 'block';
+            try {
+                menu.style.width = 'max-content';
+                menu.style.maxWidth = 'calc(100vw - 20px)';
+                const switcher = menu.querySelector('.tm-mobile-view-switcher');
+                const switcherWidth = Math.ceil(Number(switcher?.scrollWidth) || 0);
+                const viewportLimit = Math.max(220, (window.innerWidth || document.documentElement?.clientWidth || 0) - 20);
+                if (switcherWidth > 0) {
+                    const nextWidth = Math.min(viewportLimit, switcherWidth + 20);
+                    menu.style.width = `${nextWidth}px`;
+                }
+            } catch (e2) {}
             
             if (state.mobileMenuCloseHandler) {
                 try { document.removeEventListener('click', state.mobileMenuCloseHandler); } catch (e2) {}


### PR DESCRIPTION
### Motivation
- 修复桌面端浅色主题下顶栏菜单/下拉触发器在部分场景字体颜色过浅或不一致的问题，确保可读性；
- 减少移动端菜单中视图选择器两侧的多余空白，使菜单宽度更贴合视图选择器内容，提升移动端交互体验。

### Description
- 在 `task.js` 中为浅色模式顶栏菜单增加了额外的 CSS 选择器，包含顶栏下拉触发器、下拉项与浮层下拉菜单（`#tmTopbarFloatingMenu`），将其文字颜色固定为黑色（`#000000`），以保证浅色模式下字体清晰可见。 
- 将移动端视图切换器 `.tm-mobile-view-switcher` 的默认样式从 `width: max-content` 改为 `width: 100%`，使其占满容器以消除右侧空白。 
- 在 `window.tmToggleMobileMenu` 打开移动端菜单时添加了动态宽度计算逻辑：测量内部 `.tm-mobile-view-switcher.scrollWidth` 并据此设置菜单 `width`，同时设置 `maxWidth` 为 `calc(100vw - 20px)` 并对结果进行视口范围限制，避免超出屏幕或出现过多空白。 
- 所有修改集中在 `task.js`，并保持了原有的关闭/事件处理逻辑不变。

### Testing
- 已使用 `node --check task.js` 对修改后的 `task.js` 进行了语法检查，检查通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c5ce2dcc8326990b86d426d1d2f5)