### PR TITLE
fix: 强制浅色顶栏下拉菜单为深色并根据视图选择器收窄移动端菜单

### DIFF
--- a/task.js
+++ b/task.js
@@ -938,8 +938,14 @@
         [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu,
         [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn,
         [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn span,
-        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-tree-toggle-icon {
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-tree-toggle-icon,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn-info,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn-secondary,
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu > div > span {
             color: #1f2329 !important;
+        }
+        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-tree-toggle-icon path {
+            stroke: #1f2329 !important;
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-view-segmented {
@@ -26938,6 +26944,19 @@ async function __tmRefreshAfterWake(reason) {
         const open = menu.style.display !== 'none';
         if (!open) {
             menu.style.display = 'block';
+            try {
+                const switcher = menu.querySelector('.tm-mobile-view-switcher');
+                if (switcher instanceof HTMLElement) {
+                    const switcherRect = switcher.getBoundingClientRect();
+                    const sidePadding = 20; // 菜单左右各 10px 内边距
+                    const maxWidth = Math.max(0, window.innerWidth - 20);
+                    const nextWidth = Math.round(Math.min(maxWidth, Math.max(180, switcherRect.width + sidePadding)));
+                    if (nextWidth > 0) {
+                        menu.style.width = `${nextWidth}px`;
+                        menu.style.maxWidth = `${nextWidth}px`;
+                    }
+                }
+            } catch (e2) {}
             
             if (state.mobileMenuCloseHandler) {
                 try { document.removeEventListener('click', state.mobileMenuCloseHandler); } catch (e2) {}


### PR DESCRIPTION
### Motivation
- 修复浅色主题下顶栏右上角下拉菜单（桌面）被顶栏白色文字变量影响导致菜单项不可读的问题。 
- 减少移动端菜单右侧多余空白，使移动菜单宽度跟随视图选择器宽度而不是修改视图选择器样式。 

### Description
- 在 `task.js` 中为浅色主题下的 `#tmDesktopMenu` 增加更高优先级的选择器覆盖，将 `.tm-btn-info`、`.tm-btn-secondary`、`#tmDesktopMenu > div > span` 等元素的文字颜色强制设为深色，并为折叠图标路径增加 `stroke` 覆盖以保证图标描边为深色。 
- 在 `tmToggleMobileMenu` 打开菜单时加入计算逻辑：测量 `.tm-mobile-view-switcher` 的实际宽度并加上左右内边距后设置 `#tmMobileMenu` 的 `width`/`maxWidth`，从而收窄菜单并避免视图选择器右侧出现大面积空白。 
- 保持原有顶栏与选择器组件样式不变，仅通过选择器覆盖与菜单容器宽度计算实现视觉修复。 

### Testing
- 运行 `node --check task.js` 以验证语法正确，结果通过。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c84d11dc8326879e154b953f6088)