### PR TITLE
Improve desktop/mobile menu theming and responsive layout

### DIFF
--- a/task.js
+++ b/task.js
@@ -935,11 +935,33 @@
             color: #ffffff !important;
         }
 
-        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu,
-        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn,
-        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-btn span,
-        [data-theme-mode="light"] .tm-filter-rule-bar #tmDesktopMenu .tm-tree-toggle-icon {
+        [data-theme-mode="light"] #tmDesktopMenu,
+        [data-theme-mode="light"] #tmDesktopMenu .tm-btn,
+        [data-theme-mode="light"] #tmDesktopMenu .tm-btn span,
+        [data-theme-mode="light"] #tmDesktopMenu .tm-tree-toggle-icon,
+        [data-theme-mode="light"] #tmDesktopMenu .tm-btn-info,
+        [data-theme-mode="light"] #tmDesktopMenu .tm-btn-secondary,
+        [data-theme-mode="light"] #tmDesktopMenu > div > span,
+        #tmDesktopMenu.tm-desktop-menu--light,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-btn,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-btn span,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-tree-toggle-icon,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-btn-info,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-btn-secondary,
+        #tmDesktopMenu.tm-desktop-menu--light > div > span {
             color: #1f2329 !important;
+        }
+        [data-theme-mode="light"] #tmDesktopMenu .tm-btn,
+        [data-theme-mode="light"] #tmDesktopMenu .tm-btn-info,
+        [data-theme-mode="light"] #tmDesktopMenu .tm-btn-secondary,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-btn,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-btn-info,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-btn-secondary {
+            border-color: #1f2329 !important;
+        }
+        [data-theme-mode="light"] #tmDesktopMenu .tm-tree-toggle-icon path,
+        #tmDesktopMenu.tm-desktop-menu--light .tm-tree-toggle-icon path {
+            stroke: #1f2329 !important;
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-view-segmented {
@@ -970,10 +992,32 @@
 
         .tm-filter-rule-bar #tmMobileMenu .tm-mobile-only-item {
             min-width: 0;
+            max-width: 100%;
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-mobile-only-item .tm-btn {
             min-width: 0;
+            max-width: 100%;
+        }
+
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-menu-row {
+            min-width: 0;
+            max-width: 100%;
+            flex-wrap: nowrap;
+        }
+
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-menu-row > :not(.tm-mobile-menu-label) {
+            flex: 1 1 auto;
+            min-width: 0;
+            max-width: 100%;
+        }
+
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-menu-row .tm-topbar-select,
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-menu-row .bc-select-trigger,
+        .tm-filter-rule-bar #tmMobileMenu .tm-mobile-menu-row .tm-btn {
+            min-width: 0;
+            max-width: 100%;
+            overflow: hidden;
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-rule-select option {
@@ -1717,12 +1761,13 @@
             max-width: 100%;
             min-width: 0;
             display: flex;
-            flex-wrap: wrap;
+            flex-wrap: nowrap;
             justify-content: flex-start;
             height: auto !important;
             min-height: 0 !important;
             gap: 4px;
             padding: 4px 0 4px 4px;
+            overflow: hidden;
         }
 
         .tm-filter-rule-bar #tmMobileMenu .tm-mobile-view-switcher .tm-view-seg-item {
@@ -1730,8 +1775,13 @@
             height: 24px !important;
             line-height: 24px !important;
             font-size: 12px !important;
-            padding: 0 8px !important;
+            padding: 0 6px !important;
             border-radius: 6px;
+            flex: 1 1 0;
+            min-width: 0;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
         }
 
         .tm-view-seg-item:hover {
@@ -26822,6 +26872,7 @@ async function __tmRefreshAfterWake(reason) {
         const menu = document.createElement('div');
         menu.id = 'tmDesktopMenu';
         menu.className = 'tm-popup-menu bc-dropdown-menu';
+        if (!__tmIsDarkMode()) menu.classList.add('tm-desktop-menu--light');
         menu.style.cssText = `
             position: fixed;
             background: var(--tm-ui-popover);
@@ -26858,6 +26909,19 @@ async function __tmRefreshAfterWake(reason) {
             <button class="tm-btn tm-btn-info bc-btn bc-btn--sm" onclick="tmCollapseAllTasks(); document.getElementById('tmDesktopMenu').remove()" style="text-align:left; justify-content:flex-start; padding: 6px 12px;"><svg class="tm-tree-toggle-icon" viewBox="0 0 16 16" width="16" height="16" style="transform:rotate(0deg);margin-right:6px;vertical-align:middle;"><path d="M6 4l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>全部折叠</button>
             <button class="tm-btn tm-btn-info bc-btn bc-btn--sm" onclick="tmExpandAllTasks(); document.getElementById('tmDesktopMenu').remove()" style="text-align:left; justify-content:flex-start; padding: 6px 12px;"><svg class="tm-tree-toggle-icon" viewBox="0 0 16 16" width="16" height="16" style="transform:rotate(90deg);margin-right:6px;vertical-align:middle;"><path d="M6 4l4 4-4 4" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/></svg>全部展开</button>
         `;
+        if (!__tmIsDarkMode()) {
+            try {
+                menu.querySelectorAll('.tm-btn, .tm-btn span, .tm-tree-toggle-icon').forEach((el) => {
+                    try { el.style.setProperty('color', '#1f2329', 'important'); } catch (e2) {}
+                });
+                menu.querySelectorAll('.tm-btn, .tm-btn-info, .tm-btn-secondary').forEach((el) => {
+                    try { el.style.setProperty('border-color', '#1f2329', 'important'); } catch (e2) {}
+                });
+                menu.querySelectorAll('.tm-tree-toggle-icon path').forEach((el) => {
+                    try { el.style.setProperty('stroke', '#1f2329', 'important'); } catch (e2) {}
+                });
+            } catch (e2) {}
+        }
         
         // 点击外部关闭
         const closeHandler = (ev) => {
@@ -26938,6 +27002,25 @@ async function __tmRefreshAfterWake(reason) {
         const open = menu.style.display !== 'none';
         if (!open) {
             menu.style.display = 'block';
+            try {
+                const switcher = menu.querySelector('.tm-mobile-view-switcher');
+                if (switcher instanceof HTMLElement) {
+                    const switcherWidth = switcher.getBoundingClientRect().width;
+                    const sidePadding = 20; // 菜单左右各 10px 内边距
+                    const maxWidth = Math.max(0, window.innerWidth - 20);
+                    const nextWidth = Math.round(Math.min(maxWidth, Math.max(180, switcherWidth + sidePadding)));
+                    if (nextWidth > 0) {
+                        menu.style.setProperty('width', `${nextWidth}px`, 'important');
+                        menu.style.setProperty('max-width', `${nextWidth}px`, 'important');
+                        const contentMax = Math.max(120, nextWidth - sidePadding);
+                        menu.querySelectorAll('.tm-mobile-only-item, .tm-mobile-menu-row').forEach((el) => {
+                            if (!(el instanceof HTMLElement)) return;
+                            try { el.style.setProperty('max-width', `${contentMax}px`, 'important'); } catch (e3) {}
+                            try { el.style.setProperty('min-width', '0', 'important'); } catch (e3) {}
+                        });
+                    }
+                }
+            } catch (e2) {}
             
             if (state.mobileMenuCloseHandler) {
                 try { document.removeEventListener('click', state.mobileMenuCloseHandler); } catch (e2) {}


### PR DESCRIPTION
### Motivation
- Make the desktop and mobile popup menus render correctly in light mode and on narrow screens by adding explicit light-mode styling and improving responsive sizing and overflow behavior.

### Description
- Add a `tm-desktop-menu--light` class on desktop menu creation and apply additional light-mode color/border/stroke rules to ensure consistent appearance for buttons and icons in light theme by setting CSS classes and inline styles in `tmToggleDesktopMenu`.
- Update many CSS selectors and rules to target `#tmDesktopMenu` and `.tm-desktop-menu--light`, tighten color/border styling, and add `stroke` adjustments for `.tm-tree-toggle-icon` paths in light mode.
- Improve mobile menu responsiveness by adding `.tm-mobile-menu-row` and related flex/max-width rules, constraining button and select widths, and changing `.tm-mobile-view-switcher` to `flex-wrap: nowrap` with item ellipsis to prevent overflow.
- In `tmToggleMobileMenu`, dynamically compute and set a sensible menu width based on the `.tm-mobile-view-switcher` width and apply `max-width` updates to mobile-only items to avoid content overflow on small viewports.

### Testing
- Ran the project's linting (`npm run lint`) and unit test suite (`npm test`) against the modified code and both completed successfully.
- Built the frontend bundle (`npm run build`) to verify there are no syntax errors and the changes integrate cleanly into the output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4c84d11dc8326879e154b953f6088)