### PR TITLE
Reduce vertical spacing of filter rule bar in responsive layouts

### DIFF
--- a/task.js
+++ b/task.js
@@ -871,7 +871,7 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            min-height: 48px;
+            min-height: 38px;
             overflow-x: auto;
             overflow-y: visible;
             box-sizing: border-box;
@@ -1266,7 +1266,7 @@
         @media (max-width: 900px) {
             .tm-modal:not(.tm-modal--dock) .tm-filter-rule-bar {
                 flex-wrap: wrap !important;
-                padding: 10px 16px !important;
+                padding: 5px 16px !important;
                 gap: 8px !important;
             }
             
@@ -1325,7 +1325,7 @@
 
         .tm-modal.tm-modal--split-pane .tm-filter-rule-bar {
             flex-wrap: wrap;
-            padding: 10px 16px;
+            padding: 5px 16px;
             gap: 8px;
         }
 
@@ -1404,7 +1404,7 @@
             /* 筛选规则栏换行 */
             .tm-modal:not(.tm-modal--dock) .tm-filter-rule-bar {
                 flex-wrap: wrap;
-                padding: 10px 16px;
+                padding: 5px 16px;
                 gap: 8px;
             }
             
@@ -1697,7 +1697,7 @@
         }
 
         .tm-filter-rule-bar {
-            min-height: 52px;
+            min-height: 42px;
             box-sizing: border-box;
             overflow: visible;
         }


### PR DESCRIPTION
### Motivation
- Reduce vertical space used by the filter toolbar to make the header and filter rule bar more compact in narrow, split-pane, and embedded container layouts.
- Harmonize padding/min-height across media queries and container queries so the UI fits better on small viewports and modal splits.

### Description
- Updated `.tm-filter-rule-bar` `min-height` values from `48px` to `38px` and from `52px` to `42px` to reduce overall toolbar height.
- Reduced responsive paddings from `10px 16px` to `5px 16px` in the media query, container query, and split-pane rules to tighten vertical spacing.
- Preserved existing wrap, gap, and overflow behaviors while only adjusting spacing-related CSS properties.

### Testing
- Ran `npm test` and the test suite completed successfully.
- Ran `npm run lint` and code style checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4cf9db8d88326913f04add087b03d)