### PR TITLE
Compact topbar: reduce filter bar heights and padding for narrow/docked layouts

### DIFF
--- a/task.js
+++ b/task.js
@@ -871,7 +871,7 @@
             display: flex;
             justify-content: space-between;
             align-items: center;
-            min-height: 48px;
+            min-height: 38px;
             overflow-x: auto;
             overflow-y: visible;
             box-sizing: border-box;
@@ -1266,7 +1266,7 @@
         @media (max-width: 900px) {
             .tm-modal:not(.tm-modal--dock) .tm-filter-rule-bar {
                 flex-wrap: wrap !important;
-                padding: 10px 16px !important;
+                padding: 5px 16px !important;
                 gap: 8px !important;
             }
             
@@ -1325,7 +1325,7 @@
 
         .tm-modal.tm-modal--split-pane .tm-filter-rule-bar {
             flex-wrap: wrap;
-            padding: 10px 16px;
+            padding: 5px 16px;
             gap: 8px;
         }
 
@@ -1404,7 +1404,7 @@
             /* 筛选规则栏换行 */
             .tm-modal:not(.tm-modal--dock) .tm-filter-rule-bar {
                 flex-wrap: wrap;
-                padding: 10px 16px;
+                padding: 5px 16px;
                 gap: 8px;
             }
             
@@ -1697,7 +1697,7 @@
         }
 
         .tm-filter-rule-bar {
-            min-height: 52px;
+            min-height: 42px;
             box-sizing: border-box;
             overflow: visible;
         }
@@ -20721,6 +20721,7 @@ async function __tmRefreshAfterWake(reason) {
         const showAiSideDock = __tmShouldShowAiSidebar() && !!state.aiSidebarOpen && !isMobile;
         const calendarSideDockWidth = Math.max(260, Math.min(760, Math.round(Number(SettingsStore.data.calendarSideDockWidth) || 340)));
         const aiSideDockWidth = Math.max(320, Math.min(720, Math.round(Number(state.aiSidebarWidth) || 380)));
+        const topbarPadding = (isDockHost && !isMobile) ? '5px 10px' : '10px 10px';
         const bodyWithSideDockHtml = (showCalendarSideDock || showAiSideDock)
             ? `
                 <div class="tm-main-body-with-cal-dock">
@@ -20743,7 +20744,7 @@ async function __tmRefreshAfterWake(reason) {
 
         state.modal.innerHTML = `
             <div class="tm-box${showCalendarSideDock || showAiSideDock ? ' tm-box--with-cal-dock' : ''}">
-                <div class="tm-filter-rule-bar" style="padding: 10px 10px;">
+                <div class="tm-filter-rule-bar" style="padding: ${topbarPadding};">
                     <div class="tm-topbar-row" style="display:flex;align-items:center;gap:10px;flex-wrap:nowrap;justify-content:space-between;min-width:0;">
                         <div class="tm-topbar-row" style="display:flex;align-items:center;gap:10px;">
                             <div class="tm-title" style="font-size: 16px; font-weight: 700; white-space: nowrap; display:inline-flex; align-items:center; gap:4px;">


### PR DESCRIPTION
### Motivation
- Reduce vertical space used by the filter/topbar area on narrow, split-pane and docked layouts to improve usable area. 
- Make topbar padding adaptive when the modal is hosted in a dock to keep the toolbar compact.

### Description
- Reduced `.tm-filter-rule-bar` min-heights in CSS (was `48px` / `52px`, now `38px` / `42px`) to make the bar more compact. 
- Lowered padding for mobile/split/container narrow layouts from `10px` to `5px` (e.g. media queries, split-pane and container query blocks) to reduce vertical footprint. 
- Added a `topbarPadding` JS variable computed as `isDockHost && !isMobile ? '5px 10px' : '10px 10px'` and applied it to the inline `style` for `.tm-filter-rule-bar` when rendering `state.modal.innerHTML`. 
- Minor whitespace and template formatting adjustments within `task.js` around the body/topbar rendering and related constants.

### Testing
- Ran the project build with `npm run build`, which completed successfully. 
- Ran the unit test suite with `npm test`, which passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4cf9db8d88326913f04add087b03d)