### PR TITLE
优化 Dock 日历交互并新增文档页签预计进度条

### DIFF
--- a/calendar-view.js
+++ b/calendar-view.js
@@ -81,11 +81,13 @@
         deviceScheduleModalEl: null,
         deviceScheduleAbort: null,
         isMobileDevice: false,
+        isDockHost: false,
         sidebarOpen: false,
         mobileDragCloseTimer: null,
         sidebarColorMenuCloseHandler: null,
         sidebarColorMenuBindTimer: null,
         sidebarResizeCleanup: null,
+        dockHoverKeepAliveTimer: null,
         onVisibilityChange: null,
         calendarResizeObserver: null,
         scheduleCache: {
@@ -745,7 +747,7 @@
             slotLabelContent: (arg) => {
                 const d = arg?.date;
                 if (!(d instanceof Date) || Number.isNaN(d.getTime())) return '';
-                return `${pad2(d.getHours())}:${pad2(d.getMinutes())}`;
+                return `${pad2(d.getHours())}`;
             },
         };
     }
@@ -1403,7 +1405,7 @@
                 }
             }, { signal: abort.signal });
 
-            if (state.isMobileDevice) {
+            if (state.isMobileDevice || state.isDockHost) {
                 const clearDragCloseTimer = () => {
                     if (state.mobileDragCloseTimer) {
                         try { clearTimeout(state.mobileDragCloseTimer); } catch (e2) {}
@@ -1509,6 +1511,32 @@
             : !wrap.classList.contains('tm-calendar-wrap--sidebar-collapsed');
         const next = (open === undefined) ? !isOpen : !!open;
         return setCalendarSidebarOpen(wrap, next, page);
+    }
+
+    function keepDockSidebarHovered(durationMs = 1600) {
+        if (!state.isDockHost) return;
+        const panel = state.rootEl?.closest?.('.dock__item, .dock__panel');
+        if (!(panel instanceof Element)) return;
+        const ping = () => {
+            try {
+                panel.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+                panel.dispatchEvent(new MouseEvent('mousemove', { bubbles: true, clientX: panel.getBoundingClientRect().left + 8, clientY: panel.getBoundingClientRect().top + 8 }));
+            } catch (e) {}
+        };
+        ping();
+        if (state.dockHoverKeepAliveTimer) {
+            try { clearInterval(state.dockHoverKeepAliveTimer); } catch (e) {}
+            state.dockHoverKeepAliveTimer = null;
+        }
+        const started = Date.now();
+        state.dockHoverKeepAliveTimer = setInterval(() => {
+            if (Date.now() - started > Math.max(200, Number(durationMs) || 1600)) {
+                try { clearInterval(state.dockHoverKeepAliveTimer); } catch (e) {}
+                state.dockHoverKeepAliveTimer = null;
+                return;
+            }
+            ping();
+        }, 120);
     }
 
     function miniMonthKeyFromDate(d) {
@@ -7333,6 +7361,7 @@
             }
         })();
         state.isMobileDevice = !!isMobileDevice;
+        state.isDockHost = !!isDockHost;
         try {
             Promise.resolve().then(() => globalThis.tmCalendarWarmDocsToGroupCache?.()).catch(() => null);
         } catch (e) {}
@@ -7396,6 +7425,13 @@
         let _tmClickTracker = { x: 0, y: 0, ts: 0 };
         wrap.addEventListener('mousedown', (e) => {
             _tmClickTracker = { x: e.clientX, y: e.clientY, ts: Date.now() };
+            const target = e.target;
+            if (target instanceof Element && target.closest('select, .bc-select-trigger, .tm-calendar-view-select, [data-tm-cal-setting], .b3-menu, [data-type="b3-menu"]')) {
+                keepDockSidebarHovered(2200);
+            }
+        }, true);
+        wrap.addEventListener('contextmenu', () => {
+            keepDockSidebarHovered(2600);
         }, true);
         const miniHost = wrap.querySelector('.tm-calendar-mini');
         state.miniCalendarEl = miniHost;
@@ -8756,6 +8792,10 @@
             try { clearTimeout(state.mobileDragCloseTimer); } catch (e) {}
             state.mobileDragCloseTimer = null;
         }
+        if (state.dockHoverKeepAliveTimer) {
+            try { clearInterval(state.dockHoverKeepAliveTimer); } catch (e) {}
+            state.dockHoverKeepAliveTimer = null;
+        }
         state.taskDraggable = null;
         state.taskListEl = null;
         if (state._persistTimer) {
@@ -8786,6 +8826,7 @@
         state.settingsStore = null;
         state.opts = null;
         state.isMobileDevice = false;
+        state.isDockHost = false;
         state.sidebarOpen = false;
     }
 

--- a/task.js
+++ b/task.js
@@ -4760,7 +4760,7 @@
         }
 
         .tm-checklist-pane--compact .tm-checklist-leading .tm-tree-toggle {
-            left: 0;
+            left: -3px;
             width: 16px;
             min-width: 16px;
             height: 16px;
@@ -4953,7 +4953,7 @@
 
         .tm-checklist-pane--compact .tm-status-tag {
             flex: 0 0 auto;
-            margin-left: 8px;
+            margin-left: 5px;
         }
 
         .tm-checklist-side {
@@ -5270,7 +5270,7 @@
             }
 
             .tm-checklist-pane--compact .tm-checklist-leading .tm-tree-toggle {
-                left: 0;
+                left: -3px;
             }
 
             .tm-checklist-pane--compact .tm-checklist-meta-compact-doc {
@@ -7376,6 +7376,8 @@
             docPinnedByGroup: {},
             // 文档页签排序：created_desc | created_asc | name_asc | name_desc
             docTabSortMode: 'created_desc',
+            // 文档预计进度日期范围：{ [docId]: { startDate: 'YYYY-MM-DD', endDate: 'YYYY-MM-DD' } }
+            docExpectedProgressMap: {},
             // 当前选中的分组ID (UI显示用)
             currentGroupId: 'all', 
             // 任务标题级别 (h1-h6)
@@ -7948,6 +7950,7 @@
             this.data.newTaskDocId = Storage.get('tm_new_task_doc_id', '');
             this.data.newTaskDailyNoteNotebookId = String(Storage.get('tm_new_task_daily_note_notebook_id', this.data.newTaskDailyNoteNotebookId) || '').trim();
             this.data.docTabSortMode = String(Storage.get('tm_doc_tab_sort_mode', this.data.docTabSortMode) || this.data.docTabSortMode || 'created_desc').trim() || 'created_desc';
+            this.data.docExpectedProgressMap = Storage.get('tm_doc_expected_progress_map', this.data.docExpectedProgressMap) || {};
             this.data.taskAutoWrapEnabled = Storage.get('tm_task_auto_wrap_enabled', this.data.taskAutoWrapEnabled);
             this.data.taskContentWrapMaxLines = Number(Storage.get('tm_task_content_wrap_max_lines', this.data.taskContentWrapMaxLines));
             this.data.taskRemarkWrapMaxLines = Number(Storage.get('tm_task_remark_wrap_max_lines', this.data.taskRemarkWrapMaxLines));
@@ -8224,6 +8227,7 @@
             Storage.set('tm_new_task_daily_note_append_to_bottom', !!this.data.newTaskDailyNoteAppendToBottom);
             Storage.set('tm_heading_group_create_at_section_end', !!this.data.headingGroupCreateAtSectionEnd);
             Storage.set('tm_doc_tab_sort_mode', String(this.data.docTabSortMode || 'created_desc').trim() || 'created_desc');
+            Storage.set('tm_doc_expected_progress_map', this.data.docExpectedProgressMap || {});
             Storage.set('tm_task_auto_wrap_enabled', !!this.data.taskAutoWrapEnabled);
             Storage.set('tm_task_content_wrap_max_lines', Number(this.data.taskContentWrapMaxLines) || 3);
             Storage.set('tm_task_remark_wrap_max_lines', Number(this.data.taskRemarkWrapMaxLines) || 2);
@@ -8391,6 +8395,20 @@
                 normalizedPinMap[key] = list;
             });
             this.data.docPinnedByGroup = normalizedPinMap;
+            const expectedMap0 = this.data.docExpectedProgressMap;
+            const expectedMap = (expectedMap0 && typeof expectedMap0 === 'object' && !Array.isArray(expectedMap0)) ? expectedMap0 : {};
+            const normalizedExpectedMap = {};
+            Object.keys(expectedMap).forEach((k) => {
+                const key = String(k || '').trim();
+                if (!key || key === 'all') return;
+                const row = expectedMap[k];
+                if (!row || typeof row !== 'object') return;
+                const startDate = __tmNormalizeDateOnly(String(row.startDate || '').trim());
+                const endDate = __tmNormalizeDateOnly(String(row.endDate || '').trim());
+                if (!startDate || !endDate) return;
+                normalizedExpectedMap[key] = { startDate, endDate };
+            });
+            this.data.docExpectedProgressMap = normalizedExpectedMap;
             const seed = Number(this.data.docColorSeed);
             this.data.docColorSeed = (Number.isFinite(seed) && seed > 0) ? Math.floor(seed) : 1;
             const kw = Number(this.data.kanbanColumnWidth);
@@ -18895,6 +18913,41 @@ async function __tmRefreshAfterWake(reason) {
         await SettingsStore.save();
     }
 
+    function __tmGetDocExpectedProgress(docId) {
+        const id = String(docId || '').trim();
+        if (!id || id === 'all') return { startDate: '', endDate: '', percent: null };
+        const map = (SettingsStore.data.docExpectedProgressMap && typeof SettingsStore.data.docExpectedProgressMap === 'object')
+            ? SettingsStore.data.docExpectedProgressMap
+            : {};
+        const row = map[id];
+        const startDate = __tmNormalizeDateOnly(String(row?.startDate || '').trim()) || '';
+        const endDate = __tmNormalizeDateOnly(String(row?.endDate || '').trim()) || '';
+        if (!startDate || !endDate) return { startDate, endDate, percent: null };
+        const startTs = __tmParseTimeToTs(`${startDate} 00:00:00`);
+        const endTs = __tmParseTimeToTs(`${endDate} 23:59:59`);
+        if (!startTs || !endTs || endTs <= startTs) return { startDate, endDate, percent: null };
+        const now = Date.now();
+        const ratio = (now - startTs) / Math.max(1, (endTs - startTs));
+        const percent = Math.max(0, Math.min(100, Math.round(ratio * 100)));
+        return { startDate, endDate, percent };
+    }
+
+    async function __tmSetDocExpectedProgressRange(docId, startDate, endDate) {
+        const id = String(docId || '').trim();
+        if (!id || id === 'all') return;
+        const start = __tmNormalizeDateOnly(String(startDate || '').trim()) || '';
+        const end = __tmNormalizeDateOnly(String(endDate || '').trim()) || '';
+        const map0 = SettingsStore.data.docExpectedProgressMap;
+        const map = (map0 && typeof map0 === 'object' && !Array.isArray(map0)) ? map0 : {};
+        if (!start || !end) {
+            if (map[id]) delete map[id];
+        } else {
+            map[id] = { startDate: start, endDate: end };
+        }
+        SettingsStore.data.docExpectedProgressMap = map;
+        await SettingsStore.save();
+    }
+
     function __tmShowDocTabMenuAt(docId, x, y) {
         const id = String(docId || '').trim();
         if (!id || id === 'all') return;
@@ -19057,6 +19110,27 @@ async function __tmRefreshAfterWake(reason) {
             try { await SettingsStore.save(); } catch (e) {}
             render();
         }));
+        if (!isOtherBlocksTab) {
+            menu.appendChild(item('📈 设置预计进度日期…', async () => {
+                const current = __tmGetDocExpectedProgress(id);
+                const startInput = window.prompt('请输入开始日期（YYYY-MM-DD，留空则清除）', current.startDate || '');
+                if (startInput === null) return;
+                const endInput = window.prompt('请输入截止日期（YYYY-MM-DD，留空则清除）', current.endDate || '');
+                if (endInput === null) return;
+                const startDate = __tmNormalizeDateOnly(String(startInput || '').trim()) || '';
+                const endDate = __tmNormalizeDateOnly(String(endInput || '').trim()) || '';
+                if ((startDate && !endDate) || (!startDate && endDate)) {
+                    hint('⚠ 开始和截止日期需同时设置，或同时留空。', 'warning');
+                    return;
+                }
+                if (startDate && endDate && __tmParseTimeToTs(`${endDate} 00:00:00`) < __tmParseTimeToTs(`${startDate} 00:00:00`)) {
+                    hint('⚠ 截止日期不能早于开始日期。', 'warning');
+                    return;
+                }
+                await __tmSetDocExpectedProgressRange(id, startDate, endDate);
+                render();
+            }));
+        }
 
         menu.appendChild(item('🎲 重新随机未自定义颜色', async () => {
             SettingsStore.data.docColorSeed = Math.floor(Math.random() * 1000000000) + 1;
@@ -23099,6 +23173,11 @@ async function __tmRefreshAfterWake(reason) {
                             const groupProfile = __tmGetStoredGroupViewProfile(currentGroupId);
                             const profileSource = docProfile ? '页签自定义' : (groupProfile ? '分组默认' : '全局默认');
                             const profileTip = `${profileSource}: ${__tmDescribeViewProfile(docProfile || groupProfile || __tmGetViewProfilesStore().global)}`;
+                            const expected = __tmGetDocExpectedProgress(doc.id);
+                            const expectedPercent = Number.isFinite(expected.percent) ? Math.max(0, Math.min(100, Number(expected.percent))) : null;
+                            const expectedTip = (expected.startDate && expected.endDate && expectedPercent !== null)
+                                ? `&#10;预计进度 ${expectedPercent}%（${expected.startDate} → ${expected.endDate}）`
+                                : '';
                             // 预设宽度（如果缓存有值，直接渲染，减少闪烁）
                             const cachedPercent = __tmDocProgressCache?.get(doc.id) || 0;
                             // 调度异步更新
@@ -23112,7 +23191,8 @@ async function __tmRefreshAfterWake(reason) {
                                 ondragover="tmDocTabDragOver(event)" 
                                 ondrop="tmDocTabDrop(event, '${doc.id}')" 
                                 onclick="tmSwitchDoc('${doc.id}')"
-                                title="${esc(profileTip)}">
+                                title="${esc(profileTip)}${expectedTip}">
+                                <div class="tm-doc-tab-expected-progress" style="width:${expectedPercent === null ? 0 : expectedPercent}%;opacity:${expectedPercent === null ? 0 : 1};"></div>
                                 <div class="tm-doc-tab-bg" id="${pid}" style="width:${cachedPercent}%"></div>
                                 <div class="tm-doc-tab-text">${esc(doc.name)}</div>
                             </div>`;
@@ -23202,9 +23282,19 @@ async function __tmRefreshAfterWake(reason) {
                         z-index: 0;
                         pointer-events: none;
                     }
+                    .tm-doc-tab-expected-progress {
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        height: 2px;
+                        background: var(--tm-doc-color, transparent);
+                        z-index: 3;
+                        pointer-events: none;
+                        transition: width 0.2s ease;
+                    }
                     .tm-doc-tab-text {
                         position: relative;
-                        z-index: 1;
+                        z-index: 4;
                     }
                     .tm-doc-tab::after {
                         content: '';
@@ -33678,10 +33768,10 @@ async function __tmRefreshAfterWake(reason) {
                     ${embedded ? `
                         <div style="display:flex;gap:8px;align-items:center;">
                             <button class="tm-btn tm-btn-info" data-tm-detail="jump" style="padding:0 10px;height:30px;">跳转</button>
-                            ${(floating || closeable) ? `<button class="tm-btn tm-btn-gray" data-tm-detail="close" style="padding:0 10px;height:30px;display:inline-flex;align-items:center;justify-content:center;">✖</button>` : ''}
+                            ${(floating || closeable) ? `<button class="tm-btn tm-btn-gray" data-tm-detail="close" style="padding:0 10px;height:30px;display:inline-flex;align-items:center;justify-content:center;">${__tmRenderLucideIcon('x')}</button>` : ''}
                         </div>
                     ` : `
-                        <button class="tm-btn tm-btn-gray" data-tm-detail="close" style="padding:0 10px;height:30px;display:inline-flex;align-items:center;justify-content:center;">✖</button>
+                        <button class="tm-btn tm-btn-gray" data-tm-detail="close" style="padding:0 10px;height:30px;display:inline-flex;align-items:center;justify-content:center;">${__tmRenderLucideIcon('x')}</button>
                     `}
                 </div>
 


### PR DESCRIPTION
### Motivation

- 修复并统一 Dock/移动端在从日历侧栏拖拽任务后侧栏行为，改善拖拽到时间轴的体验。 
- 防止 Dock 悬浮展开后在点击下拉或右键菜单时立即缩回，提升交互稳定性。 
- 在紧凑清单视图微调子任务折叠指示器位置与间距以匹配视觉需求。 
- 简化日历时间刻度显示为小时，和移动/侧边栏视图保持一致，并为文档页签增加可配置的预计进度显示。 

### Description

- 在 `calendar-view.js` 中新增 `isDockHost` 状态并将移动端拖拽后自动隐藏侧栏的逻辑扩展到 Dock 宿主; 将时间刻度渲染 (`slotLabelContent`) 从 `HH:mm` 改为仅小时 `HH`。 
- 在 `calendar-view.js` 中新增 `keepDockSidebarHovered` keep-alive 机制并在侧栏上绑定 `mousedown/contextmenu` 钩子以在打开下拉或右键菜单时短时维持 Dock 悬浮状态，且在卸载时清理计时器。 
- 在 `task.js` 中新增文档级配置 `docExpectedProgressMap`（本地存储键 `tm_doc_expected_progress_map`），增加规范化/加载/保存逻辑以及 `__tmGetDocExpectedProgress` / `__tmSetDocExpectedProgressRange` 两个辅助函数用于读取与写入预计进度区间并计算当前百分比。 
- 在文档页签右键菜单中加入“📈 设置预计进度日期…”项，使用 `prompt` 简易输入开始/截止日期并做基本校验后持久化。 
- 在文档页签渲染中插入顶部 2px 进度条 DOM 和样式 (`.tm-doc-tab-expected-progress`)，并在页签 `title` 中显示预计进度与起止日期提示。 
- 将任务详情弹层的关闭按钮从文本符号 `✖` 替换为 Lucide 图标渲染（调用 `__tmRenderLucideIcon('x')`）。 
- 在 `task.js` 的紧凑清单样式中将子任务折叠指示器左移 3px 并把状态标签左边距从 `8px` 调整为 `5px`，同步补丁处的重复样式声明。 

### Testing

- 已对修改后的脚本做语法检查，执行 `node --check calendar-view.js` 并成功通过。 
- 已对修改后的脚本做语法检查，执行 `node --check task.js` 并成功通过.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca23cde3f083269d509d4868f2d19c)