### PR TITLE
Add `isolation: isolate` to panel containers

### DIFF
--- a/index.js
+++ b/index.js
@@ -487,6 +487,7 @@ module.exports = class TaskHorizonPlugin extends Plugin {
                 this.element.style.display = "flex";
                 this.element.style.flexDirection = "column";
                 this.element.style.height = "100%";
+                this.element.style.isolation = "isolate";
                 globalThis.__taskHorizonTabElement = this.element;
                 if (typeof globalThis.__taskHorizonMount === "function") {
                     globalThis.__taskHorizonMount(this.element);
@@ -780,6 +781,7 @@ module.exports = class TaskHorizonPlugin extends Plugin {
         root.style.flex = "1 1 auto";
         root.style.position = "relative";
         root.style.overflow = "hidden";
+        root.style.isolation = "isolate";
         if (root.dataset.tmDockReactivateBound !== "1") {
             root.addEventListener("click", () => {
                 try {


### PR DESCRIPTION
topBarPlugin 的样式是：z-index: 23; 会被 dock 的头部给遮住。

可以用样式隔离来重置内部 zindex，就不会影响到外层的任何东西了。

隔离前：
<img width="918" height="320" alt="Image" src="https://github.com/user-attachments/assets/1b35f010-1575-488f-b834-f5f4cfe7dff2" />

隔离后：
<img width="908" height="254" alt="CleanShot 2026-04-07 at 22 16 33@2x" src="https://github.com/user-attachments/assets/406cdf2d-d9a3-478c-ae00-d701661c7c61" />
