### PR TITLE
feat(task): add cancelled task icon and patching logic

### DIFF
--- a/index.js
+++ b/index.js
@@ -412,6 +412,13 @@ module.exports = class TaskHorizonPlugin extends Plugin {
         await loadStyleText(CALENDAR_VIEW_CSS_PATH, "calendar-view.css");
         this.mountExistingTabs();
         this.scheduleTaskDockRecovery("post-load", { delayMs: 60 });
+
+        this.addIcons(`
+            <symbol id="iconTaskCancelled" viewBox="0 0 32 32">
+                <path d="M28.444 0h-24.889c-1.956 0-3.556 1.6-3.556 3.556v24.889c0 1.956 1.6 3.556 3.556 3.556h24.889c1.956 0 3.556-1.6 3.556-3.556v-24.889c0-1.956-1.6-3.556-3.556-3.556zM28.444 28.445h-24.889v-24.889h24.889v24.889z"></path>
+                <path d="M24.485 10.343l-2.828-2.828-5.657 5.657-5.657-5.657-2.828 2.828 5.657 5.657-5.657 5.657 2.828 2.828 5.657-5.657 5.657 5.657 2.828-2.828-5.657-5.657z"></path>
+            </symbol>
+        `);
     }
 
     ensureCustomTab() {

--- a/quickbar.js
+++ b/quickbar.js
@@ -4134,6 +4134,7 @@
             quickbarDisposed = true;
             try { stopQuickbar(); } catch (e) {}
             try { stopInlineMeta(); } catch (e) {}
+            try { stopTaskIconPatch(); } catch (e) {}
             try { if (__tmQBStatusRenderStorageHandler) window.removeEventListener('storage', __tmQBStatusRenderStorageHandler); } catch (e) {}
             __tmQBStatusRenderStorageHandler = null;
             try { document.removeEventListener('contextmenu', __tmQBOnContextmenuCapture, true); } catch (e) {}
@@ -4151,6 +4152,90 @@
         else stopQuickbar();
         refreshInlineMetaMode(true);
     }
+
+    // ==================== Task Icon Patch ====================
+    // data-task="-" 的任务项，图标应显示为 iconTaskCancelled 而非 iconCheck
+    const taskIconMap = {
+        '-': 'iconTaskCancelled',
+    };
+    let taskIconPatchObserver = null;
+    let taskIconPatchEbHandlers = [];
+
+    function patchTaskIcons(root) {
+        const scope = root || document;
+        try {
+            scope.querySelectorAll('.li[data-task]').forEach((li) => {
+                const marker = li.getAttribute('data-task');
+                const targetIcon = taskIconMap[marker];
+                const use = li.querySelector(':scope > .protyle-action--task use');
+                if (!use) return;
+                const current = use.getAttribute('xlink:href');
+                if (targetIcon) {
+                    if (current !== '#' + targetIcon) use.setAttribute('xlink:href', '#' + targetIcon);
+                } else {
+                    const isPatched = Object.values(taskIconMap).some((icon) => current === '#' + icon);
+                    if (isPatched) use.setAttribute('xlink:href', marker === ' ' ? '#iconUncheck' : '#iconCheck');
+                }
+            });
+        } catch (e) {}
+    }
+
+    function startTaskIconPatch() {
+        patchTaskIcons(document);
+        try {
+            taskIconPatchObserver = new MutationObserver((mutations) => {
+                let needPatch = false;
+                for (const m of mutations) {
+                    if (m.type === 'attributes' && m.attributeName === 'data-task') {
+                        needPatch = true;
+                        break;
+                    }
+                    if (m.type === 'childList') {
+                        const nodes = [...m.addedNodes];
+                        if (nodes.some((n) => n.nodeType === Node.ELEMENT_NODE && (n.matches?.('[data-task]') || n.querySelector?.('[data-task]')))) {
+                            needPatch = true;
+                            break;
+                        }
+                    }
+                }
+                if (needPatch) patchTaskIcons(document);
+            });
+            document.querySelectorAll('.protyle-wysiwyg').forEach((root) => {
+                taskIconPatchObserver.observe(root, { childList: true, subtree: true, attributes: true, attributeFilter: ['data-task'] });
+            });
+        } catch (e) {}
+        try {
+            const eb = globalThis.__taskHorizonPluginInstance?.eventBus || window.siyuan?.eventBus;
+            if (eb && typeof eb.on === 'function') {
+                const onStatic = (e) => {
+                    const protyle = e?.protyle || e?.detail?.protyle;
+                    const root = protyle?.wysiwyg?.element;
+                    setTimeout(() => patchTaskIcons(root || document), 20);
+                };
+                const onDynamic = (e) => {
+                    const protyle = e?.protyle || e?.detail?.protyle;
+                    const root = protyle?.wysiwyg?.element;
+                    setTimeout(() => patchTaskIcons(root || document), 20);
+                };
+                eb.on('loaded-protyle-static', onStatic);
+                eb.on('loaded-protyle-dynamic', onDynamic);
+                taskIconPatchEbHandlers.push({ eb, event: 'loaded-protyle-static', handler: onStatic });
+                taskIconPatchEbHandlers.push({ eb, event: 'loaded-protyle-dynamic', handler: onDynamic });
+            }
+        } catch (e) {}
+    }
+
+    function stopTaskIconPatch() {
+        try { taskIconPatchObserver?.disconnect?.(); } catch (e) {}
+        taskIconPatchObserver = null;
+        taskIconPatchEbHandlers.forEach(({ eb, event, handler }) => {
+            try { eb.off(event, handler); } catch (e) {}
+        });
+        taskIconPatchEbHandlers = [];
+    }
+
+    // 启动 task icon patch
+    startTaskIconPatch();
 
     // 思源笔记 API 请求封装
     async function requestApi(url, data, method = 'POST') {

--- a/quickbar.js
+++ b/quickbar.js
@@ -4165,19 +4165,20 @@
         const scope = root || document;
         try {
             scope.querySelectorAll('.li[data-task]').forEach((li) => {
-                const marker = li.getAttribute('data-task');
-                const targetIcon = taskIconMap[marker];
+                const targetIcon = taskIconMap[li.getAttribute('data-task')];
+                if (!targetIcon) return;
                 const use = li.querySelector(':scope > .protyle-action--task use');
-                if (!use) return;
-                const current = use.getAttribute('xlink:href');
-                if (targetIcon) {
-                    if (current !== '#' + targetIcon) use.setAttribute('xlink:href', '#' + targetIcon);
-                } else {
-                    const isPatched = Object.values(taskIconMap).some((icon) => current === '#' + icon);
-                    if (isPatched) use.setAttribute('xlink:href', marker === ' ' ? '#iconUncheck' : '#iconCheck');
+                if (use && use.getAttribute('xlink:href') !== '#' + targetIcon) {
+                    use.setAttribute('xlink:href', '#' + targetIcon);
                 }
             });
         } catch (e) {}
+    }
+
+    let _patchTimer = null;
+    function schedulePatchTaskIcons(root, delay = 0) {
+        clearTimeout(_patchTimer);
+        _patchTimer = setTimeout(() => patchTaskIcons(root), delay);
     }
 
     function startTaskIconPatch() {
@@ -4198,7 +4199,10 @@
                         }
                     }
                 }
-                if (needPatch) patchTaskIcons(document);
+                if (needPatch) {
+                    // 延迟执行，确保在思源完成所有 DOM 操作（如重写 <use> href）之后
+                    schedulePatchTaskIcons(document, 0);
+                }
             });
             document.querySelectorAll('.protyle-wysiwyg').forEach((root) => {
                 taskIconPatchObserver.observe(root, { childList: true, subtree: true, attributes: true, attributeFilter: ['data-task'] });
@@ -4210,22 +4214,44 @@
                 const onStatic = (e) => {
                     const protyle = e?.protyle || e?.detail?.protyle;
                     const root = protyle?.wysiwyg?.element;
-                    setTimeout(() => patchTaskIcons(root || document), 20);
+                    schedulePatchTaskIcons(root || document, 20);
                 };
                 const onDynamic = (e) => {
                     const protyle = e?.protyle || e?.detail?.protyle;
                     const root = protyle?.wysiwyg?.element;
-                    setTimeout(() => patchTaskIcons(root || document), 20);
+                    schedulePatchTaskIcons(root || document, 20);
+                };
+                const onWsMain = (msg) => {
+                    const cmd = msg?.detail?.cmd || msg?.cmd;
+                    if (cmd !== 'transactions') return;
+                    try {
+                        const data = msg?.detail?.data || msg?.data;
+                        const txs = Array.isArray(data) ? data : (data ? [data] : []);
+                        let hasUpdate = false;
+                        for (const tx of txs) {
+                            const ops = tx?.doOperations || tx?.operations || [];
+                            for (const op of ops) {
+                                if (op?.action === 'update') { hasUpdate = true; break; }
+                            }
+                            if (hasUpdate) break;
+                        }
+                        if (!hasUpdate) return;
+                    } catch (e) {}
+                    schedulePatchTaskIcons(document, 60);
                 };
                 eb.on('loaded-protyle-static', onStatic);
                 eb.on('loaded-protyle-dynamic', onDynamic);
+                eb.on('ws-main', onWsMain);
                 taskIconPatchEbHandlers.push({ eb, event: 'loaded-protyle-static', handler: onStatic });
                 taskIconPatchEbHandlers.push({ eb, event: 'loaded-protyle-dynamic', handler: onDynamic });
+                taskIconPatchEbHandlers.push({ eb, event: 'ws-main', handler: onWsMain });
             }
         } catch (e) {}
     }
 
     function stopTaskIconPatch() {
+        clearTimeout(_patchTimer);
+        _patchTimer = null;
         try { taskIconPatchObserver?.disconnect?.(); } catch (e) {}
         taskIconPatchObserver = null;
         taskIconPatchEbHandlers.forEach(({ eb, event, handler }) => {


### PR DESCRIPTION
Add new icon for cancelled tasks (data-task="-") and implement mutation observer to dynamically update task icons. The patch ensures cancelled tasks show the correct icon instead of the default checkmark.

<img width="484" height="112" alt="TRAE CN 2026-04-16 19 56 13" src="https://github.com/user-attachments/assets/9982502e-1832-4542-ad1f-7bd6209170c6" />

支持自定义状态对应的图标

close: #28 