### PR TITLE
Show horizontal scrollbar on oversized kanban

### DIFF
--- a/task-horizon.css
+++ b/task-horizon.css
@@ -3647,15 +3647,42 @@ select.tm-btn-secondary {
     height: 100%;
     min-height: 0;
     overscroll-behavior: contain;
-    touch-action: pan-y;
-    scrollbar-width: none;
-    -ms-overflow-style: none;
+    /* `pan-x pan-y` (not `pan-y`) lets touch users natively swipe to the
+       overflowed right-hand columns. The per-card drag handler
+       (tmKanbanCardPointerDown) still calls preventDefault when it needs to
+       take over, so card dragging is unaffected. */
+    touch-action: pan-x pan-y;
+    /* Show a thin horizontal scrollbar so the kanban is reachable when its
+       columns overflow the viewport. Mirrors the styling used on
+       .tm-body--list so the two views look consistent. */
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in srgb, var(--tm-secondary-text) 28%, transparent) transparent;
     position: relative;
 }
 
 .tm-body.tm-body--kanban::-webkit-scrollbar {
     width: 0;
-    height: 0;
+    height: 6px;
+}
+
+.tm-body.tm-body--kanban::-webkit-scrollbar:vertical {
+    width: 0;
+}
+
+.tm-body.tm-body--kanban::-webkit-scrollbar-track {
+    background: transparent;
+    border-radius: 999px;
+}
+
+.tm-body.tm-body--kanban::-webkit-scrollbar-thumb:horizontal {
+    background: color-mix(in srgb, var(--tm-secondary-text) 28%, transparent);
+    border-radius: 999px;
+    border: 1px solid transparent;
+    background-clip: padding-box;
+}
+
+.tm-body.tm-body--kanban::-webkit-scrollbar-corner {
+    background: transparent;
 }
 
 .tm-body.tm-body--whiteboard {


### PR DESCRIPTION
When kanban columns overflow the viewport, .tm-body--kanban had overflow-x: auto but hid the scrollbar on every engine (scrollbar-width: none, -ms-overflow-style: none, ::-webkit-scrollbar height: 0) AND pinned touch-action: pan-y. The custom card drag handler only attaches to cards, not the body's empty regions, so right-hand columns were rendered but unreachable: mouse users had no scrollbar to drag and no wheel fallback, and touch users could not swipe horizontally because pan-y blocked native panning.

Switch touch-action to "pan-x pan-y" so the browser pans the kanban horizontally on touch (the per-card drag still calls preventDefault when it takes over). Replace the scrollbar-hiding rules with a thin horizontal scrollbar mirroring the style already used on .tm-body--list (scrollbar-width: thin + scrollbar-color for Firefox; ::-webkit-scrollbar height 6px with track / thumb / corner rules for Chromium and WebKit). Vertical scrollbar stays zero-width since overflow-y is hidden.

This PR fixes #79 