### PR TITLE
修复悬浮条首次点击 AI 按钮无法加载 AI 模块

### DIFF
--- a/quickbar.js
+++ b/quickbar.js
@@ -901,6 +901,20 @@
         }
     }
 
+    async function ensureAiRuntimeLoaded() {
+        try {
+            if (globalThis.__tmAI?.loaded) return true;
+        } catch (e) {}
+        const loader = globalThis.__taskHorizonEnsureAiModuleLoaded;
+        if (typeof loader !== 'function') return !!globalThis.__tmAI?.loaded;
+        try {
+            const ok = await loader();
+            return !!(ok && globalThis.__tmAI?.loaded);
+        } catch (e) {
+            return false;
+        }
+    }
+
     function markBlockMenuTrigger(target, source) {
         const blockEl = getBlockElementFromTarget(target);
         lastBlockMenuTrigger = {
@@ -3420,6 +3434,9 @@
                             if (!taskIdForAi) {
                                 showMessage('未找到任务', true, 1800);
                                 return;
+                            }
+                            if (typeof globalThis.tmAiOptimizeTaskName !== 'function') {
+                                await ensureAiRuntimeLoaded();
                             }
                             if (typeof globalThis.tmAiOptimizeTaskName === 'function') {
                                 await globalThis.tmAiOptimizeTaskName(taskIdForAi);


### PR DESCRIPTION
悬浮条在 AI 按钮点击时仅检查 tmAiOptimizeTaskName 是否存在，若任务管理器主界面未打开则 ai.js 尚未加载，提示"AI 模块尚未加载"。现按需调用 __taskHorizonEnsureAiModuleLoaded 触发加载。修复 #81 